### PR TITLE
Ability to disable log with level ERROR if key not exists

### DIFF
--- a/examples/todo-java/src/main/java/todo/backend/FeatureHubSource.java
+++ b/examples/todo-java/src/main/java/todo/backend/FeatureHubSource.java
@@ -28,6 +28,8 @@ public class FeatureHubSource implements FeatureHub {
   String analyticsCid = "";
   @ConfigKey("feature-service.sdk")
   String clientSdk = "jersey3";
+  @ConfigKey("feature-service.logs.error-if-key-not-defined")
+  boolean logErrorIfKeyNotDefined = true;
 
   private final FeatureRepositoryContext repository;
   private final EdgeFeatureHubConfig config;
@@ -39,7 +41,7 @@ public class FeatureHubSource implements FeatureHub {
 
     config = new EdgeFeatureHubConfig(featureHubUrl, sdkKey);
 
-    repository = new ClientFeatureRepository(5);
+    repository = new ClientFeatureRepository(5, logErrorIfKeyNotDefined);
     repository.registerValueInterceptor(true, new SystemPropertyValueInterceptor());
 
     if (analyticsCid.length() > 0 && analyticsKey.length() > 0) {


### PR DESCRIPTION
*Context*
We use feature hub to manage feature toggles

Also, we have 2 additional point
- not all feature toggles exist in feature hub, the responsible person often creates it when feature toggle is needed
- we have several feature toggle sources with priority, for example, feature hub, application properties, environment, etc

*Issue*
When we try to get feature value in java (io.featurehub.client.ClientFeatureRepository#getFeatureState) first time, then we have such log for our applications `FeatureHub error: application requesting use of invalid key after initialization: XXX`.

This happens only for the first request for the feature toggle (not existing in feature hub), after instance of application was restarted (because of java.util.Map#computeIfAbsent used) 

So in monitoring of our applications we have error cases by logs

*Fix*
I try to provide an ability to skip this log by configuration, because looks like that is usual case when feature toggle not exists in feature hub