### PR TITLE
Allow for timeout if featurehub is unreachable, so we don't block indefinitely

### DIFF
--- a/client-java-core/src/main/java/io/featurehub/client/EdgeFeatureHubConfig.java
+++ b/client-java-core/src/main/java/io/featurehub/client/EdgeFeatureHubConfig.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ServiceLoader;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 public class EdgeFeatureHubConfig implements FeatureHubConfig {
@@ -76,6 +77,16 @@ public class EdgeFeatureHubConfig implements FeatureHubConfig {
     try {
       final Future<ClientContext> futureContext = newContext().build();
       futureContext.get();
+    } catch (Exception e) {
+      log.error("Failed to initialize FeatureHub client", e);
+    }
+  }
+
+  @Override
+  public void init(long timeout, TimeUnit unit) {
+    try {
+      final Future<ClientContext> futureContext = newContext().build();
+      futureContext.get(timeout, unit);
     } catch (Exception e) {
       log.error("Failed to initialize FeatureHub client", e);
     }

--- a/client-java-core/src/main/java/io/featurehub/client/FeatureHubConfig.java
+++ b/client-java-core/src/main/java/io/featurehub/client/FeatureHubConfig.java
@@ -2,6 +2,7 @@ package io.featurehub.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 public interface FeatureHubConfig {
@@ -20,6 +21,13 @@ public interface FeatureHubConfig {
    * to re-request data from the server each time you change your context.
    */
   void init();
+
+  /**
+   * If you are using a client evaluated feature context, this will initialise the service and block until
+   * the provided timeout or until you have received your first set of features. Server Evaluated contexts
+   * should not use it because it needs to re-request data from the server each time you change your context.
+   */
+  void init(long timeout, TimeUnit unit);
 
   /**
    * The API Key indicates this is going to be server based evaluation


### PR DESCRIPTION
Addresses https://github.com/featurehub-io/featurehub-java-sdk/issues/39

This allows for the easy ability to timeout if for some reason featurehub is unreachable.